### PR TITLE
extender: fix configure-scheduler sed issue

### DIFF
--- a/deploy/extender-configuration/configure-scheduler.sh
+++ b/deploy/extender-configuration/configure-scheduler.sh
@@ -24,5 +24,5 @@ sed -i '/^  dnsPolicy: ClusterFirstWithHostNet/d' $MANIFEST_FILE
 sed -e "/    - kube-scheduler/a\\
     - --policy-configmap=scheduler-extender-policy\n    - --policy-configmap-namespace=kube-system" $MANIFEST_FILE -i
 sed -e "/spec/a\\
-  dnsPolicy: ClusterFirstWithHostNet" $MANIFEST_FILE
+  dnsPolicy: ClusterFirstWithHostNet" $MANIFEST_FILE -i
 


### PR DESCRIPTION
Fix the typo that sed -i should be used.

Signed-off-by: Alek Du <alek.du@intel.com>