### PR TITLE
changed default address for cache 

### DIFF
--- a/cmd/tas-scheduler-extender/main.go
+++ b/cmd/tas-scheduler-extender/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+
 	"github.com/intel/telemetry-aware-scheduling/pkg/cache"
 	"github.com/intel/telemetry-aware-scheduling/pkg/scheduler"
 )
@@ -13,7 +14,7 @@ func main() {
 	flag.StringVar(&port, "port", "9001", "port on which the scheduler extender will listen")
 	flag.StringVar(&certFile, "cert", "/etc/kubernetes/pki/ca.crt", "cert file extender will use for authentication")
 	flag.StringVar(&keyFile, "key", "/etc/kubernetes/pki/ca.key", "key file extender will use for authentication")
-	flag.StringVar(&cacheEndpoint, "cacheEndpoint", "http://localhost:8111/cache/", "root at which the cache can be reached for reading")
+	flag.StringVar(&cacheEndpoint, "cacheEndpoint", "http://127.0.0.1:8111/cache/", "root at which the cache can be reached for reading")
 	flag.BoolVar(&unsafe, "unsafe", false, "unsafe instances of telemetry aware scheduler will be served over simple http.")
 	flag.Parse()
 	cacheReader := cache.RemoteClient{}


### PR DESCRIPTION
Explicitly using 127.0.0.1 for the scheduler cache address to reduce issues relating to dns and 
some intermittent undiagnosed networking problems caused by dns lookup etc.