### PR TITLE
Add security context for the mount container

### DIFF
--- a/deploy/tas-deployment.yaml
+++ b/deploy/tas-deployment.yaml
@@ -30,7 +30,9 @@ spec:
         - --key=/tas/cert/tls.key
         - --cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         image: tas-extender
-        imagePullPolicy: IfNotPresent 
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          readOnlyRootFilesystem: true 
         volumeMounts:
         - name: certs
           mountPath: /tas/cert


### PR DESCRIPTION
Mount container's root file system set as read-only in
the deployment file.