### PR TITLE
Add more flexible hadolint scan

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -19,10 +19,7 @@ jobs:
     name: Hadolint
     steps:
     - uses: actions/checkout@v2
-#     Each dockerfile needs to be pointed to individually with this setup
-    - uses: brpaz/hadolint-action@v1.2.1
-      with:
-        dockerfile: deploy/images/Dockerfile
+    - run: wget -q https://github.com/hadolint/hadolint/releases/download/v2.1.0/hadolint-Linux-x86_64 -O hadolint; chmod +x hadolint ; find . -type f \( -name "Dockerfile*" \) -print0 | xargs -n 1 -0 ./hadolint ;
   gofmt-imports:
     runs-on: ubuntu-latest
     name: Go Fmt and Go Import

--- a/deploy/images/Dockerfile
+++ b/deploy/images/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.12.1 as build
 RUN adduser -D -u 10001 tas
 
 FROM scratch
+WORKDIR /
 COPY extender .
 COPY --from=build /etc/passwd /etc/passwd
 EXPOSE 9001/tcp


### PR DESCRIPTION
Added a more flexible script for running hadolint as part of the
github actions workflow. This version will actively look for all
Dockerfiles to be found in the repo and scan them. The scan will
fail if any issue is found in any Dockerfile. This should ensure
that PRs with new Dockerfiles will meet the Hadolint standards.